### PR TITLE
chore: use per-repo npm publish

### DIFF
--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -24,8 +24,8 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 cd $(dirname $0)/..
 
-NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google_cloud_npm_token)
-echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/google-cloud-os-login-npm-token)
+echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 npm install
 npm publish --access=public


### PR DESCRIPTION
Test using per-repository token to publish nodejs-os-login before rolling out.