### PR TITLE
build: fix publish key fetching

### DIFF
--- a/.kokoro/publish.sh
+++ b/.kokoro/publish.sh
@@ -24,7 +24,7 @@ python3 -m releasetool publish-reporter-script > /tmp/publisher-script; source /
 
 cd $(dirname $0)/..
 
-NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/google-cloud-os-login-npm-token)
+NPM_TOKEN=$(cat $KOKORO_KEYSTORE_DIR/73713_google-cloud-os-login-npm-token)
 echo "//wombat-dressing-room.appspot.com/:_authToken=${NPM_TOKEN}" > ~/.npmrc
 
 npm install


### PR DESCRIPTION
The last publish job failed because I misconfigured the job script. Let's give that a try again.