### PR TITLE
chore: release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://www.npmjs.com/package/@google-cloud/os-login?activeTab=versions
 
+### [0.3.3](https://www.github.com/googleapis/nodejs-os-login/compare/v0.3.2...v0.3.3) (2019-04-30)
+
+
+### Bug Fixes
+
+* include 'x-goog-request-params' header in requests ([#167](https://www.github.com/googleapis/nodejs-os-login/issues/167)) ([074051d](https://www.github.com/googleapis/nodejs-os-login/commit/074051d))
+
 ## v0.3.2
 
 03-18-2019 13:47 PDT
@@ -138,4 +145,3 @@
 - chore: test on node10 ([#22](https://github.com/googleapis/nodejs-os-login/pull/22))
 - chore: lock files maintenance ([#20](https://github.com/googleapis/nodejs-os-login/pull/20))
 - chore: workaround for repo-tools EPERM ([#19](https://github.com/googleapis/nodejs-os-login/pull/19))
-

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/os-login",
   "description": "Google Cloud OS Login API client for Node.js",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,7 +14,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@google-cloud/os-login": "^0.3.2"
+    "@google-cloud/os-login": "^0.3.3"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
this was auto-generated using release-please and https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits.

If we're happy with how the output looks, let's land it and see if `autorelease` picks up on the changes appropriately.